### PR TITLE
updates to change execute() to exec_create/exec_start

### DIFF
--- a/containerHelper.py
+++ b/containerHelper.py
@@ -88,6 +88,8 @@ def display_status(args):
 
 parser = argparse.ArgumentParser()
 
+parser.add_argument("--version", help="API Version", default='auto')
+
 parser.add_argument("container", help="Container name")
 
 subparsers = parser.add_subparsers(title="Counters", description="Available counters", dest="dataType")
@@ -109,7 +111,8 @@ network_parser.set_defaults(func=display_network)
 status_parser = subparsers.add_parser("status", help="Display the container status")
 status_parser.set_defaults(func=display_status)
 
-c = Client(**(kwargs_from_env()))
-
 args = parser.parse_args()
+
+c = Client(version=args.version, **(kwargs_from_env()))
+
 args.func(args)


### PR DESCRIPTION
`docker-py` no longer supports `c.execute()` - it has been broken out into `c.exec_create()` and `c.exec_start()`. This commit mostly covers that, and in the process solved a couple of other issues I encountered in my env. I've made the whole thing more generic and thus more flexible. It also works under Python2, so you can close out that issue from Feb.
1. works under python2
2. network function uses `/proc/net/dev` for statistics, which should always work
3. works on images that don't have `ifconfig` installed
